### PR TITLE
gem: add racc dependency for Ruby 3.3+

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,10 +17,9 @@ jobs:
     - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: unit testing
       env:
         CI: true
       run: |
-        gem install bundler rake
-        bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,9 @@ jobs:
     - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: unit testing
       env:
         CI: true
       run: |
-        gem install bundler rake
-        bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         os:
           - macOS-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         os:
           - windows-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,10 +17,9 @@ jobs:
     - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: unit testing
       env:
         CI: true
       run: |
-        gem install bundler rake
-        bundle install --jobs 4 --retry 3
         ridk exec bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in fluent-plugin-parser-protobuf.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake"

--- a/fluent-plugin-parser-protobuf.gemspec
+++ b/fluent-plugin-parser-protobuf.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "google-protobuf", ["~> 3.12"]
   spec.add_runtime_dependency "ruby-protocol-buffers"
   spec.add_runtime_dependency "webrick"
+  spec.add_runtime_dependency "racc"
 end

--- a/fluent-plugin-parser-protobuf.gemspec
+++ b/fluent-plugin-parser-protobuf.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license = "Apache-2.0"
 
-  spec.add_development_dependency 'test-unit', '~> 3.3.0'
+  spec.add_development_dependency 'test-unit', '~> 3.3'
   spec.add_runtime_dependency "fluentd", [">= 1.0", "< 2"]
   spec.add_runtime_dependency "google-protobuf", ["~> 3.12"]
   spec.add_runtime_dependency "ruby-protocol-buffers"


### PR DESCRIPTION
Since Ruby 3.3, `racc` has been promoted from default gems to bundled gems.
If it is not specified as a dependency, executing with bundler causes a LoadError.
This PR adds `racc` as a runtime dependency to fix this issue.

https://github.com/ruby/ruby/blob/ruby_3_3/gems/bundled_gems#L23